### PR TITLE
build: fix `unresolved symbol` on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -59,6 +59,8 @@ fn main() {
 		base_config.file("libusb/libusb/os/poll_windows.c");
 		base_config.file("libusb/libusb/os/threads_windows.c");
 		base_config.file("libusb/libusb/os/windows_winusb.c");
+		base_config.file("libusb/libusb/os/windows_nt_common.c");
+		base_config.file("libusb/libusb/os/windows_usbdk.c");
 
 		base_config.define("DEFAULT_VISIBILITY", Some(""));
 		if !target_env.contains("gnu") {


### PR DESCRIPTION
(Merging this from xobs/libusb-sys to my master branch to allow easier building.)

With the latest libusb, the list of files that need to be included in a
Windows build has increased:

    note: liblibusb_sys-85d9362602910437.rlib(core.o) : error LNK2001: unresolved external symbol usbi_backend
          liblibusb_sys-85d9362602910437.rlib(io.o) : error LNK2001: unresolved external symbol usbi_backend
          liblibusb_sys-85d9362602910437.rlib(descriptor.o) : error LNK2001: unresolved external symbol usbi_backend
   test-ed47120c25f5188f.exe : fatal error LNK1120: 1 unresolved externals

The symbol `usbi_backend` is now found in `windows_nt_common.c`.  THis
file also references `usbdk_backend`, so we must include that file as
well.

With this change, it is now possible to build on Windows.

Signed-off-by: Sean Cross <xxxx@xxxx.io>